### PR TITLE
fix: cleaning up engine requirements and updating dev deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install npm@7
-        run: npm install -g npm@7
+      # Node 16 ships with npm@8 so for compatibility reasons we're upping this for everything else.
+      - name: Install npm@8
+        if: matrix.node-version != '16.x'
+        run: npm install -g npm@8
 
       - name: Install deps
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,7 @@
         "webpack-cli": "^4.9.1"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16",
-        "npm": "^7"
+        "node": "^12 || ^14 || ^16"
       },
       "peerDependencies": {
         "react": "16.x"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "url": "git://github.com/readmeio/variable.git"
   },
   "engines": {
-    "node": "^12 || ^14 || ^16",
-    "npm": "^7"
+    "node": "^12 || ^14 || ^16"
   },
   "scripts": {
     "build": "webpack",


### PR DESCRIPTION
## 🧰 What's being changed?

Installing this library with npm@8 generates a warning that it actually wants npm@7. Since either work, and the npm requirement is only really there for local development I'm removing it.

## 🧬 Testing

* [ ] Tests pass?