### PR TITLE
fix: match non-english characters in variables + glossary terms

### DIFF
--- a/__tests__/index.test.jsx
+++ b/__tests__/index.test.jsx
@@ -125,4 +125,24 @@ describe('VARIABLE_REGEXP', () => {
   it('should match against periods', () => {
     expect('<<api.key>>').toMatch(new RegExp(VARIABLE_REGEXP));
   });
+
+  it('should match against hyphens', () => {
+    expect('<<api-key>>').toMatch(new RegExp(VARIABLE_REGEXP));
+  });
+
+  it('should match against spaces', () => {
+    expect('<<api key>>').toMatch(new RegExp(VARIABLE_REGEXP));
+  });
+
+  it('should match against colons', () => {
+    expect('<<glossary:term>>').toMatch(new RegExp(VARIABLE_REGEXP));
+  });
+
+  it('should be case insensitive', () => {
+    expect('<<api.key>>').toMatch(new RegExp(VARIABLE_REGEXP));
+  });
+
+  it('should match non-english characters', () => {
+    expect('<<片仮名>>').toMatch(new RegExp(VARIABLE_REGEXP));
+  });
 });

--- a/__tests__/index.test.jsx
+++ b/__tests__/index.test.jsx
@@ -145,7 +145,7 @@ describe('VARIABLE_REGEXP', () => {
   it('should match non-english characters', () => {
     expect('<<片仮名>>').toMatch(new RegExp(VARIABLE_REGEXP));
   });
-  
+
   it('should match against colons with non-english characters', () => {
     expect('<<glossary:ラベル>>').toMatch(new RegExp(VARIABLE_REGEXP));
   });

--- a/__tests__/index.test.jsx
+++ b/__tests__/index.test.jsx
@@ -139,10 +139,14 @@ describe('VARIABLE_REGEXP', () => {
   });
 
   it('should be case insensitive', () => {
-    expect('<<api.key>>').toMatch(new RegExp(VARIABLE_REGEXP));
+    expect('<<api.KeY>>').toMatch(new RegExp(VARIABLE_REGEXP));
   });
 
   it('should match non-english characters', () => {
     expect('<<片仮名>>').toMatch(new RegExp(VARIABLE_REGEXP));
+  });
+  
+  it('should match against colons with non-english characters', () => {
+    expect('<<glossary:ラベル>>').toMatch(new RegExp(VARIABLE_REGEXP));
   });
 });

--- a/index.jsx
+++ b/index.jsx
@@ -161,6 +161,6 @@ module.exports.Variable = Variable;
 // - \<<apiKey\>> - escaped variables
 // - <<apiKey>> - regular variables
 // - <<glossary:glossary items>> - glossary
-module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-\p{L}:.\s]+)(?:\\)?>>/u.source;
+module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-\p{L}:.\s]+)(?:\\)?>>/iu.source;
 module.exports.VariablesContext = VariablesContext;
 module.exports.SelectedAppContext = SelectedAppContext;

--- a/index.jsx
+++ b/index.jsx
@@ -161,6 +161,6 @@ module.exports.Variable = Variable;
 // - \<<apiKey\>> - escaped variables
 // - <<apiKey>> - regular variables
 // - <<glossary:glossary items>> - glossary
-module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-\w:.\s]+)(?:\\)?>>/.source;
+module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-\p{L}:.\s]+)(?:\\)?>>/u.source;
 module.exports.VariablesContext = VariablesContext;
 module.exports.SelectedAppContext = SelectedAppContext;


### PR DESCRIPTION
## 🧰 What's being changed?
Apparently RegEx's `\w` selector is seriously anglo-centric, and only matches against Latinate language alphabetic characters. (You can see the breakage [here](https://my-group.readme.io/kingtest/docs/glossary-testing).) This renders both our variable and glossary components entirely useless in non-english language docs! That is 💩 y. And, as it turns out, quite easy to fix…[^1]

- [x] Update our variable pattern to use Unicode `\p{L}` selector.

## 🧬 Testing

We can't directly test this till the change hits ReadMe proper, but you can see the pattern in action [here](https://regexr.com/6e759). Browser support for the RegEx `/u` Unicode flag is [pretty good](https://caniuse.com/mdn-javascript_builtins_regexp_unicode) too![^2]


[^1]: [Per this very well written StackOverflow answer](https://stackoverflow.com/questions/150033/regular-expression-to-match-non-ascii-characters).
[^2]: Barring Internet goddamned Explorer, of fu•king course…
