### PR TITLE
fix(🔥): match underscored var names

### DIFF
--- a/__tests__/index.test.jsx
+++ b/__tests__/index.test.jsx
@@ -138,6 +138,10 @@ describe('VARIABLE_REGEXP', () => {
     expect('<<glossary:term>>').toMatch(new RegExp(VARIABLE_REGEXP));
   });
 
+  it('should match against underscores', () => {
+    expect('<<api_key>>').toMatch(new RegExp(VARIABLE_REGEXP));
+  });
+
   it('should be case insensitive', () => {
     expect('<<api.KeY>>').toMatch(new RegExp(VARIABLE_REGEXP));
   });

--- a/index.jsx
+++ b/index.jsx
@@ -161,6 +161,6 @@ module.exports.Variable = Variable;
 // - \<<apiKey\>> - escaped variables
 // - <<apiKey>> - regular variables
 // - <<glossary:glossary items>> - glossary
-module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-\p{L}:.\s]+)(?:\\)?>>/iu.source;
+module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-_\p{L}:.\s]+)(?:\\)?>>/iu.source;
 module.exports.VariablesContext = VariablesContext;
 module.exports.SelectedAppContext = SelectedAppContext;


### PR DESCRIPTION
## 🧰 What's being changed?

Akamai was noticing some issues with their variables after #66—apparently the `\w` selector matches underscores but the new Unicode `\p{Letter}` selector doesn’t.

- [x] Explicitly match underscored variable names.
