### PR TITLE
chore(regex): match numeric characters

### DIFF
--- a/__tests__/index.test.jsx
+++ b/__tests__/index.test.jsx
@@ -146,6 +146,12 @@ describe('VARIABLE_REGEXP', () => {
     expect('<<api.KeY>>').toMatch(new RegExp(VARIABLE_REGEXP));
   });
 
+  it('should match numeric characters', () => {
+    expect('<<P2P>>').toMatch(new RegExp(VARIABLE_REGEXP));
+    expect('<<123>>').toMatch(new RegExp(VARIABLE_REGEXP));
+    expect('<<glossary:123>>').toMatch(new RegExp(VARIABLE_REGEXP));
+  });
+
   it('should match non-english characters', () => {
     expect('<<片仮名>>').toMatch(new RegExp(VARIABLE_REGEXP));
   });

--- a/index.jsx
+++ b/index.jsx
@@ -161,6 +161,6 @@ module.exports.Variable = Variable;
 // - \<<apiKey\>> - escaped variables
 // - <<apiKey>> - regular variables
 // - <<glossary:glossary items>> - glossary
-module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-_\p{L}:.\s]+)(?:\\)?>>/iu.source;
+module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-_\p{L}:.\s\d]+)(?:\\)?>>/iu.source;
 module.exports.VariablesContext = VariablesContext;
 module.exports.SelectedAppContext = SelectedAppContext;


### PR DESCRIPTION
## 🧰 What's being changed?

- [x] Match numeric characters using the `\d` selector.
