### PR TITLE
fix: don't look at defaults for data if they're null

### DIFF
--- a/__tests__/index.test.jsx
+++ b/__tests__/index.test.jsx
@@ -18,6 +18,12 @@ describe('single variable', () => {
     expect(container).toHaveTextContent('123456');
   });
 
+  it('should not fail if `defaults` has null entries', () => {
+    const { container } = render(<Variable {...props} defaults={[null]} />);
+
+    expect(container).toHaveTextContent('123456');
+  });
+
   it('should render default if value not set', () => {
     const { container } = render(<Variable {...props} defaults={[{ name: 'apiKey', default: 'default' }]} user={{}} />);
 

--- a/index.jsx
+++ b/index.jsx
@@ -23,7 +23,7 @@ class Variable extends React.Component {
   }
 
   getDefault() {
-    const def = this.props.defaults.find(d => d.name === this.props.variable) || {};
+    const def = this.props.defaults.filter(Boolean).find(d => d.name === this.props.variable) || {};
     if (def.default) return def.default;
     return this.props.variable.toUpperCase();
   }


### PR DESCRIPTION
| 🚥 Fix RM-5103 |
| :-- |

## 🧰 Changes

This fixes a fatal error being thrown right now where if the `defaults` array this library is receiving has `null` entries this library will throw an error when attempting to look at `null.name`.

## 🧬 QA & Testing

See the test I added.