### PR TITLE
fix: stop looking for data in `user.keys` if its an empty array

### DIFF
--- a/__tests__/index.test.jsx
+++ b/__tests__/index.test.jsx
@@ -77,6 +77,18 @@ describe('multiple variables', () => {
     changeSelected: () => {},
   };
 
+  it('should not fail if user has `keys` but its empty', () => {
+    const p = {
+      ...props,
+      user: {
+        keys: [],
+      },
+    };
+
+    const { container } = render(<Variable {...p} />);
+    expect(container).toHaveTextContent('APIKEY');
+  });
+
   it('should render the first of multiple values', () => {
     const { container } = render(<Variable {...props} />);
 

--- a/index.jsx
+++ b/index.jsx
@@ -31,7 +31,7 @@ class Variable extends React.Component {
   getSelectedValue(selected) {
     const { user } = this.props;
     let selectedValue = {};
-    if (Array.isArray(user.keys)) {
+    if (Array.isArray(user.keys) && user.keys.length) {
       selectedValue = selected ? user.keys.find(key => key.name === selected) : user.keys[0];
     }
     return selectedValue;
@@ -108,7 +108,7 @@ class Variable extends React.Component {
   render() {
     const { user, selected } = this.props;
 
-    if (Array.isArray(user.keys)) {
+    if (Array.isArray(user.keys) && user.keys.length) {
       return (
         <span>
           {!this.state.showDropdown && (


### PR DESCRIPTION
## 🧰 Changes

* [x] Fixes a bug where if `user.keys` is present and an array but empty we may throw an exception because we'd try to look for data in an `undefined` variable.

## 🧬 QA & Testing

Check the test I added.