### PR TITLE
fix: dont match linebreaks

### DIFF
--- a/__tests__/index.test.jsx
+++ b/__tests__/index.test.jsx
@@ -228,5 +228,6 @@ describe('VARIABLE_REGEXP', () => {
   it('should NOT match against newlines', () => {
     expect('<<what the\nfuck>>').not.toMatch(new RegExp(VARIABLE_REGEXP));
     expect('<<what the\rfuck>>').not.toMatch(new RegExp(VARIABLE_REGEXP));
+    expect('<<what the\r\nfuck>>').not.toMatch(new RegExp(VARIABLE_REGEXP));
   });
 });

--- a/__tests__/index.test.jsx
+++ b/__tests__/index.test.jsx
@@ -224,4 +224,9 @@ describe('VARIABLE_REGEXP', () => {
   it('should match against colons with non-english characters', () => {
     expect('<<glossary:ラベル>>').toMatch(new RegExp(VARIABLE_REGEXP));
   });
+
+  it('should NOT match against newlines', () => {
+    expect('<<what the\nfuck>>').not.toMatch(new RegExp(VARIABLE_REGEXP));
+    expect('<<what the\rfuck>>').not.toMatch(new RegExp(VARIABLE_REGEXP));
+  });
 });

--- a/index.jsx
+++ b/index.jsx
@@ -185,6 +185,6 @@ module.exports.Variable = Variable;
 // - \<<apiKey\>> - escaped variables
 // - <<apiKey>> - regular variables
 // - <<glossary:glossary items>> - glossary
-module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-_\p{L}:.\s\d]+)(?:\\)?>>/iu.source;
+module.exports.VARIABLE_REGEXP = /(?:\\)?<<((?:(?![\r\n])[-_\p{L}:.\s\d])+)(?:\\)?>>/iu.source;
 module.exports.VariablesContext = VariablesContext;
 module.exports.SelectedAppContext = SelectedAppContext;


### PR DESCRIPTION
| 🚥 Resolves CX-138 |
| :----------------- |

## 🧰 Changes

This PR prevents matching against line breaks.

## 🧬 QA & Testing

Consider the following markdown:

````
```
some bash << readline
not a var >> log.txt
```
````
