### PR TITLE
feat: allow different prop

### DIFF
--- a/__tests__/index.test.jsx
+++ b/__tests__/index.test.jsx
@@ -36,9 +36,16 @@ describe('single variable', () => {
     expect(container).toHaveTextContent('APIKEY');
   });
 
+  it('should allow the use of "name" as a prop', () => {
+    const { variable, ...rest } = props;
+    const { container } = render(<Variable {...rest} name="apiKey" />);
+
+    expect(container).toHaveTextContent('123456');
+  });
+
   it('should render auth dropdown if default and oauth enabled', () => {
     const { container } = render(
-      <Variable {...props} defaults={[{ name: 'apiKey', default: 'default' }]} oauth user={{}} />,
+      <Variable {...props} defaults={[{ name: 'apiKey', default: 'default' }]} oauth user={{}} />
     );
 
     fireEvent.click(container.querySelector('.variable-underline'));
@@ -125,7 +132,7 @@ describe('multiple variables', () => {
         user={{
           keys: [{ name: 'project1', apiKey: '123' }, { name: 'project2', apiKey: '456' }, { name: 'project3' }],
         }}
-      />,
+      />
     );
 
     fireEvent.click(container.querySelector('.variable-underline'));
@@ -149,7 +156,7 @@ describe('multiple variables', () => {
           keys: [{ name: 'project1', apiKey: '123' }],
         }}
         variable={'topLevelProperty'}
-      />,
+      />
     );
 
     expect(container).toHaveTextContent('this is coming straight from the top');
@@ -165,7 +172,7 @@ describe('multiple variables', () => {
         {...props}
         defaults={[{ name: 'testDefault', default: 'this is a default value' }]}
         variable={'testDefault'}
-      />,
+      />
     );
 
     expect(container).toHaveTextContent('this is a default value');

--- a/__tests__/index.test.jsx
+++ b/__tests__/index.test.jsx
@@ -45,7 +45,7 @@ describe('single variable', () => {
 
   it('should render auth dropdown if default and oauth enabled', () => {
     const { container } = render(
-      <Variable {...props} defaults={[{ name: 'apiKey', default: 'default' }]} oauth user={{}} />
+      <Variable {...props} defaults={[{ name: 'apiKey', default: 'default' }]} oauth user={{}} />,
     );
 
     fireEvent.click(container.querySelector('.variable-underline'));
@@ -132,7 +132,7 @@ describe('multiple variables', () => {
         user={{
           keys: [{ name: 'project1', apiKey: '123' }, { name: 'project2', apiKey: '456' }, { name: 'project3' }],
         }}
-      />
+      />,
     );
 
     fireEvent.click(container.querySelector('.variable-underline'));
@@ -156,7 +156,7 @@ describe('multiple variables', () => {
           keys: [{ name: 'project1', apiKey: '123' }],
         }}
         variable={'topLevelProperty'}
-      />
+      />,
     );
 
     expect(container).toHaveTextContent('this is coming straight from the top');
@@ -172,7 +172,7 @@ describe('multiple variables', () => {
         {...props}
         defaults={[{ name: 'testDefault', default: 'this is a default value' }]}
         variable={'testDefault'}
-      />
+      />,
     );
 
     expect(container).toHaveTextContent('this is a default value');

--- a/index.jsx
+++ b/index.jsx
@@ -11,6 +11,7 @@ class Variable extends React.Component {
     super(props);
     this.state = { showDropdown: false };
 
+    this.getName = this.getName.bind(this);
     this.toggleVarDropdown = this.toggleVarDropdown.bind(this);
     this.toggleAuthDropdown = this.toggleAuthDropdown.bind(this);
     this.renderVarDropdown = this.renderVarDropdown.bind(this);
@@ -22,10 +23,15 @@ class Variable extends React.Component {
     this.props.changeSelected(event.target.value);
   }
 
+  getName() {
+    return this.props.name || this.props.variable;
+  }
+
   getDefault() {
-    const def = this.props.defaults.filter(Boolean).find(d => d.name === this.props.variable) || {};
+    const def = this.props.defaults.filter(Boolean).find(d => d.name === this.getName()) || {};
+
     if (def.default) return def.default;
-    return this.props.variable.toUpperCase();
+    return this.getName().toUpperCase();
   }
 
   getSelectedValue(selected) {
@@ -43,9 +49,9 @@ class Variable extends React.Component {
   // Additionally do not show the dropdown if there is only a
   // single key, since there's nothing to change it to.
   shouldShowVarDropdown(selected) {
-    const { user, variable } = this.props;
+    const { user } = this.props;
 
-    return !!this.getSelectedValue(selected)[variable] && Array.isArray(user.keys) && user.keys.length > 1;
+    return !!this.getSelectedValue(selected)[this.getName()] && Array.isArray(user.keys) && user.keys.length > 1;
   }
 
   // Return value in this order
@@ -54,10 +60,9 @@ class Variable extends React.Component {
   // - default value
   // - uppercase key
   getValue(selected) {
-    const { variable } = this.props;
     const selectedValue = this.getSelectedValue(selected);
 
-    const value = selectedValue[variable] || this.props.user[variable] || this.getDefault();
+    const value = selectedValue[this.getName()] || this.props.user[this.getName()] || this.getDefault();
 
     return typeof value === 'object' ? JSON.stringify(value) : value;
   }
@@ -142,12 +147,13 @@ class Variable extends React.Component {
 Variable.propTypes = {
   changeSelected: PropTypes.func.isRequired,
   defaults: PropTypes.arrayOf(PropTypes.shape({ default: PropTypes.string, name: PropTypes.string })).isRequired,
+  name: PropTypes.string,
   oauth: PropTypes.bool,
   selected: PropTypes.string.isRequired,
   user: PropTypes.shape({
     keys: PropTypes.array,
   }).isRequired,
-  variable: PropTypes.string.isRequired,
+  variable: PropTypes.string,
 };
 
 Variable.defaultProps = {

--- a/index.jsx
+++ b/index.jsx
@@ -24,14 +24,17 @@ class Variable extends React.Component {
   }
 
   getName() {
-    return this.props.name || this.props.variable;
+    const name = this.props.name || this.props.variable;
+    if (!name) throw new TypeError("Missing prop 'name' or 'variable' for Variable component!");
+
+    return name;
   }
 
   getDefault() {
     const def = this.props.defaults.filter(Boolean).find(d => d.name === this.getName()) || {};
 
     if (def.default) return def.default;
-    return this.getName()?.toUpperCase() || undefined;
+    return this.getName().toUpperCase();
   }
 
   getSelectedValue(selected) {

--- a/index.jsx
+++ b/index.jsx
@@ -31,7 +31,7 @@ class Variable extends React.Component {
     const def = this.props.defaults.filter(Boolean).find(d => d.name === this.getName()) || {};
 
     if (def.default) return def.default;
-    return this.getName().toUpperCase();
+    return this.getName()?.toUpperCase() || undefined;
   }
 
   getSelectedValue(selected) {


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

Allows the use of the prop: "name".

```
<Variable name="apiKey" />
```

Since this is going to be a "public" component soon, we thought a less repetitive prop would be appropraite?

## 🧬 QA & Testing

- [ ] tests pass?
