### PR TITLE
chore: remove react 19 dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,6 @@
         "jest": "^30.0.3",
         "jest-environment-jsdom": "^30.0.2",
         "prettier": "^3.0.3",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
         "terser-webpack-plugin": "^5.3.7",
         "webpack": "^5.88.2",
         "webpack-cli": "^5.1.4"
@@ -35,8 +33,8 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "react": "18.x || 19.x",
-        "react-dom": "18.x || 19.x"
+        "react": "18.x",
+        "react-dom": "18.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10237,8 +10235,8 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10250,8 +10248,8 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -10701,8 +10699,8 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -19326,7 +19324,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -19335,7 +19333,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -19639,7 +19637,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "prop-types": "^15.8.1"
   },
   "peerDependencies": {
-    "react": "18.x || 19.x",
-    "react-dom": "18.x || 19.x"
+    "react": "18.x",
+    "react-dom": "18.x"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.22.15",
@@ -41,8 +41,6 @@
     "jest": "^30.0.3",
     "jest-environment-jsdom": "^30.0.2",
     "prettier": "^3.0.3",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
     "terser-webpack-plugin": "^5.3.7",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4"


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

Removes supporting `react@19`.

I _think_ this is causing downstream dependency resolution issues.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
